### PR TITLE
DesiLinkr/issue-center#3 [Feature] Setup Routes in `auth_app` for Sign-In & Sign-Up

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -81,7 +81,6 @@ export default defineConfig({
   },
   plugins: [
     new Dotenv(),
-
     new rspack.HtmlRspackPlugin({
       template: "./index.html",
     }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,32 @@
 import ReactDOM from "react-dom/client";
 
+import { createBrowserRouter,
+  RouterProvider,} from "react-router-dom";
+import SignUp from "./SignUp";
+import SignIn from "./SignIn";
+const router = createBrowserRouter([
+  {
+    path: "/sign_up",
+    element: <SignUp/> ,
+  },
+  {
+    path: "/sign_in",
+    element:<SignIn/> ,
+  },
+  {
+    path: "*",
+    element: <div>404 - Page Not Found</div>,
+  },
+  
+]); 
+ 
+const App = () => {
 
-const App = () => (
-  <div >
-    
-  </div>
-);
+
+  return      <RouterProvider router={router} /> 
+  
+
+}
 
 const root = ReactDOM.createRoot(document.getElementById("app") as HTMLElement);
 

--- a/src/SignIn.tsx
+++ b/src/SignIn.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const SignIn = () => {
+  return (
+    <div>SignIn</div>
+  )
+}
+
+export default SignIn

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const SignUp = () => {
+  return (
+    <div>
+
+
+    </div>
+  )
+}
+
+export default SignUp


### PR DESCRIPTION
## 📄 Related Issue
Closes DesiLinkr/issue-center#3  
Blocks DesiLinkr/issue-center#1, DesiLinkr/issue-center#2

## 📌 Overview
This PR adds  routes `/sign_in` and `/sign_up` in the `auth_app` micro frontend to enable isolated development of authentication pages.

## 📁 Scope

- Adds React Router routes for sign-in and sign-up pages.
- Currently renders simple placeholder components.
- Ready for Module Federation integration.
