### PR TITLE
fix [Bug] TS6059 Error

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,10 +14,11 @@
     "allowImportingTsExtensions": true,
     "baseUrl": ".",
     "paths": {
+      "*": ["./@mf-types/*"],
       "@/*": ["./*"],
     }
   },
-  "include": ["src"],
+"include": ["src", "components", "lib"],
   "ts-node": {
     "compilerOptions": {
       "module": "CommonJS"


### PR DESCRIPTION
File 'X' is not under 'rootDir' 'src' when adding exposes in Module Federation