### PR TITLE
Removed_SSO_Button_from_Sign-In,Sign-Up_Pages

### DIFF
--- a/src/SignIn.tsx
+++ b/src/SignIn.tsx
@@ -50,7 +50,7 @@ const SignIn = () => {
    <TypographySmall text='Or' className='relative bottom-2 bg-white   w-8 justify-center flex'></TypographySmall>
    </div>
    </div>
-   <div className='flex  flex-col justify-between h-[8rem]'>
+   <div className='flex  flex-col justify-between h-[5.5rem]'>
    <div className=' relative  '>
    <Button variant="outline" className='w-full rounded-sm text-sm'>Continue with Google</Button>
  
@@ -63,7 +63,6 @@ const SignIn = () => {
    <Button variant="outline" className='w-full rounded-sm text-sm'>Continue with Apple</Button>
    </div>
 
-   <Button variant="outline" className='w-full rounded-sm text-sm'>Continue with Single Sign On</Button>
  
    
    </div>

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -17,12 +17,10 @@ const SignUp = () => {
 <div className=' flex justify-center    lg:w-[55vw] h-full '>
 <div className=' relative  bottom-[60px]  '>
 <TypographyH2 text='Create your account' className=''  />
-<div className="text-sm text-center mb-6 mt-7 text-gray-800 ">
+<div className="text-sm  mb-6 mt-7 text-gray-800 w-full  ">
           <span>Already have an account? </span>
           <a href={`${process.env.SHELL_APP}/login`} className="text-red-500 hover:underline">Log in</a>
-          <span> or </span>
-          <a href={`${process.env.SHELL_APP}/sso-login`} className="text-red-500 hover:underline">Log in with SSO</a>
-        </div>
+         </div>
 <div className='flex flex-col  md:flex-col-reverse'>
 <form>
 <div className="grid w-full max-w-sm items-center gap-2">
@@ -50,7 +48,7 @@ const SignUp = () => {
 </div>
 <div className=' relative  '>
 <Button variant="outline" className='w-full rounded-sm text-sm'>Continue with Google</Button>
-<img src='google-logo-icon.png' className='absolute top-2.5 left-16  ' width={16} height={16}></img>
+<img src='google-logo-icon.png' className='absolute top-2.5 left-10  ' width={16} height={16}></img>
 </div>
 </div>
 </div>


### PR DESCRIPTION
# 🧹 Chore: Remove SSO Button from Sign-In & Sign-Up Pages

Closes DesiLinkr/issue-center#6

---

## 🔧 Summary

Removed all SSO-related UI and logic from both `SignIn` and `SignUp` pages in `auth_app`, as per the updated decision to drop SSO support.

---

## ✅ What Was Done

- 🔥 Removed **"Continue with Single Sign-On"** button from `SignIn.tsx`
- 🔥 Removed **"Log in with SSO"** button from `SignUp.tsx`
- 🧼 Cleaned up any related logic, props, or conditionals used for rendering SSO
- ✅ Verified that both pages now match the **updated Figma design** (without SSO)
- 📱 UI tested on multiple screen sizes to confirm **responsiveness and layout integrity**

---



## 🎯 Acceptance Criteria

- [x] No SSO-related buttons or placeholders present on Sign-In/Sign-Up pages
- [x] No dead code or conditional logic related to SSO
- [x] Page responsiveness remains intact

---
